### PR TITLE
Address issue #16

### DIFF
--- a/lib/turbo-sprockets/tasks/assets.rake
+++ b/lib/turbo-sprockets/tasks/assets.rake
@@ -116,7 +116,8 @@ namespace :assets do
   end
 
   namespace :cache do
-    task :clean => ['tmp:create', "assets:environment"] do
+    task :clean => ["assets:environment"] do
+      FileUtils.mkdir_p(File.join(::Rails.root.to_s, *%w(tmp cache assets)))
       ::Rails.application.assets.cache.clear
     end
   end


### PR DESCRIPTION
The tmp:create task was destroying any symlinks already in the tmp/ dir.

I also found that any capistrano symlink creation tasks that create tmp/cache need to be hooked before asset compilation or else the cache/assets directory is created and the symlinking fails.
