### PR TITLE
Update README section about Capistrano versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,14 @@ Please let me know if you have any problems with other gems, and I will either f
 
 ### Capistrano
 
-`turbo-sprockets-rails3` should work out of the box with Capistrano. The latest version of Capistrano now supports asset rollback and automatic expiry.
+`turbo-sprockets-rails3` should work out of the box with the latest Capistrano on the `master` branch, which now supports asset rollback and automatic expiry (implemented [here](https://github.com/capistrano/capistrano/pull/281)).
+
+Until they release a new version of the gem, add the following line to your `Gemfile`:
+
+
+```ruby
+gem 'capistrano', :github => 'capistrano/capistrano'
+```
 
 ### Heroku
 
@@ -106,3 +113,5 @@ If you would like to view debugging information in your terminal during the `ass
 config.log_level = :debug
 config.logger = Logger.new(STDOUT)
 ```
+
+


### PR DESCRIPTION
The latest gem doesn't support automatic expiry yet, so users need to fetch the latest `master`.
