### PR TITLE
Bring back CLEAN_EXPIRED_ASSETS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Enjoy your lightning fast deploys!
 
 ## Removing Expired Assets
 
-`turbo-sprockets-rails3` provides a Rake task called `assets:clean_expired`. You can run this task after `assets:precompile` to remove outdated assets.
+`turbo-sprockets-rails3` provides a Rake task called `assets:clean_expired`. You can run this task after `assets:precompile` to remove outdated assets. To automatically run this `assets:clean_expired` task after `assets:precompile`, you can set the `CLEAN_EXPIRED_ASSETS` environment variable to `true` (`CLEAN_EXPIRED_ASSETS=true rake assets:precompile`).
 
 An asset will be deleted if it is no longer referenced by `manifest.yml`, and hasn't been actively deployed for more than a day (default).
 

--- a/lib/turbo-sprockets/tasks/assets.rake
+++ b/lib/turbo-sprockets/tasks/assets.rake
@@ -196,3 +196,8 @@ task_enhancements.each do |task_name, actions|
     Rake::Task[task_name].enhance &proc
   end
 end
+
+# Clean expired assets after asset precompile, if CLEAN_EXPIRED_ASSETS is set
+Rake::Task["assets:precompile:all"].enhance do
+  Rake::Task["assets:clean_expired:all"].invoke if ENV['CLEAN_EXPIRED_ASSETS'].in? %w(true yes 1)
+end


### PR DESCRIPTION
There used to be a `CLEAN_EXPIRED_ASSETS` environment variable that allowed for cleaning expired assets at the same time as the `precompile` task was being executed. It was removed in 0171cf06bdd5aad1fd72ed6f44ff419bd8b42ce7 due to Heroku not supporting these environment variables. However, I would still find this very useful for our environment, so this pull request brings back that functionality.

Allowing this to execute at the same time as the precompile task can save the overhead of having to execute two separate rake tasks (and loading the whole Rails environment inside each one). We're currently looking to make the switch to JRuby for a few projects and this time savings becomes even more significant there since JRuby is slower to startup new processes.
