### PR TITLE
Add stub support

### DIFF
--- a/test/assets_test.rb
+++ b/test/assets_test.rb
@@ -39,6 +39,18 @@ module ApplicationTests
       assert !File.exists?(filename), "#{filename} does exist"
     end
 
+    test "assets support stub" do
+      app_file "app/assets/javascripts/application.js", "//= require jquery\n//= require foo\n//= stub frameworks"
+      app_file "app/assets/javascripts/jquery.js", "jQuery = 1;"
+      app_file "app/assets/javascripts/frameworks.js", "//= require jquery"
+      app_file "app/assets/javascripts/foo.js", "foo = 1;"
+
+      require "#{app_path}/config/environment"
+
+      get "/assets/application.js"
+      assert_equal "foo = 1;", last_response.body.strip
+    end
+
     test "assets routes have higher priority" do
       app_file "app/assets/javascripts/demo.js.erb", "a = <%= image_path('rails.png').inspect %>;"
 

--- a/turbo-sprockets-rails3.gemspec
+++ b/turbo-sprockets-rails3.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_runtime_dependency "sprockets", ">= 2.0.0"
+  s.add_runtime_dependency "sprockets", ">= 2.2.0"
   s.add_runtime_dependency "railties",  "> 3.2.8", '< 4.0.0'
 end


### PR DESCRIPTION
`stub` was added in `2.2.0`. It took me a while to figure out why it wasn't working when I realized it was effectively monkey patched out by `turbo-sprockets-rails3`. This adds it back in and bumps up the sprockets version dependency (which I realize may not be something you want to do). We could always detect support for it and optionally perform the stub removal.
