### PR TITLE
Remove postprocessors from unprocessed asset

### DIFF
--- a/lib/sprockets/unprocessed_asset.rb
+++ b/lib/sprockets/unprocessed_asset.rb
@@ -6,10 +6,11 @@ module Sprockets
       @environment = environment
       context = environment.context_class.new(environment, logical_path, pathname)
       attributes = environment.attributes_for(pathname)
+      preprocessors = environment.preprocessors(content_type)
 
-      # Remove all engine processors except ERB to return unprocessed source file
+      # Remove all postprocessors and engines except ERB to return unprocessed source file
       allowed_engines = [Tilt::ERBTemplate]
-      processors = attributes.processors - (attributes.engines - allowed_engines)
+      processors = preprocessors + (attributes.engines & allowed_engines)
 
       @source = context.evaluate(pathname, :processors => processors)
 
@@ -20,7 +21,7 @@ module Sprockets
         allowed_engines << Sass::Rails::ScssTemplate if defined?(Sass::Rails::ScssTemplate)
         allowed_engines << Sass::Rails::SassTemplate if defined?(Sass::Rails::SassTemplate)
         allowed_engines << Less::Rails::LessTemplate if defined?(Less::Rails::LessTemplate)
-        processors = attributes.processors - (attributes.engines - allowed_engines)
+        processors = preprocessors + (attributes.engines & allowed_engines)
         @source = context.evaluate(pathname, :processors => processors)
       end
 


### PR DESCRIPTION
Unprocessed assets are evaluated using all postprocessors but without any engines. It causes unexpected behavior and errors because postprocessor expects data allready parsed  by an engine.

I think simply removing postprocessors and leaving just preprocessors and engines for unprocessed assets shouldn't cause any problems.

I found this issue while using https://github.com/ai/autoprefixer-rails. Great gem and i really hope it gets the support it deserves, including compatibility with this also very useful gem.
