### PR TITLE
Remove postprocessors and keep right order

### DIFF
--- a/lib/sprockets/unprocessed_asset.rb
+++ b/lib/sprockets/unprocessed_asset.rb
@@ -6,10 +6,11 @@ module Sprockets
       @environment = environment
       context = environment.context_class.new(environment, logical_path, pathname)
       attributes = environment.attributes_for(pathname)
+      preprocessors = environment.preprocessors(content_type)
 
-      # Remove all engine processors except ERB to return unprocessed source file
+      # Remove all postprocessors and engines except ERB to return unprocessed source file
       allowed_engines = [Tilt::ERBTemplate]
-      processors = attributes.processors - (attributes.engines - allowed_engines)
+      processors = preprocessors + (allowed_engines & attributes.engines)
 
       @source = context.evaluate(pathname, :processors => processors)
 
@@ -20,7 +21,7 @@ module Sprockets
         allowed_engines << Sass::Rails::ScssTemplate if defined?(Sass::Rails::ScssTemplate)
         allowed_engines << Sass::Rails::SassTemplate if defined?(Sass::Rails::SassTemplate)
         allowed_engines << Less::Rails::LessTemplate if defined?(Less::Rails::LessTemplate)
-        processors = attributes.processors - (attributes.engines - allowed_engines)
+        processors = preprocessors + (allowed_engines & attributes.engines)
         @source = context.evaluate(pathname, :processors => processors)
       end
 


### PR DESCRIPTION
Sorry about previous error in #66. Didn't notice `attributes.engines` return array of engines in reverse order and because of it scss, sass and less engines were ahead of erb in processing order... Fixed it by changing arguments in `attributes.engines & allowed_engines` to `allowed_engines & attributes.engines`
