### PR TITLE
Fixing ticket #90.  Where if Rails.assets.cache is nil Rake assets:cache it throws an exception

### DIFF
--- a/lib/turbo-sprockets/tasks/assets.rake
+++ b/lib/turbo-sprockets/tasks/assets.rake
@@ -181,7 +181,9 @@ namespace :assets do
   namespace :cache do
     task :clean => ["assets:environment"] do
       FileUtils.mkdir_p(File.join(::Rails.root.to_s, *%w(tmp cache assets)))
-      ::Rails.application.assets.cache.clear
+      if ::Rails.application.assets.cache
+        ::Rails.application.assets.cache.clear
+      end
     end
   end
 

--- a/test/assets_test.rb
+++ b/test/assets_test.rb
@@ -537,6 +537,20 @@ module ApplicationTests
       assert_equal 0, Dir.entries(Rails.application.assets.cache.cache_path).size - 2 # reject [".", ".."]
     end
 
+    test "assets:cache:clean should not throw an Exception if assets.cache is nil" do
+      ENV["RAILS_ENV"] = "production"
+
+      precompile!
+      require "#{app_path}/config/environment"
+      Rails.application.assets.instance_variable_set(:@cache, nil)
+
+      quietly do
+        assert_nothing_raised do
+          Dir.chdir(app_path){ `bundle exec rake assets:cache:clean` }
+        end
+      end
+    end
+
     private
 
     def app_with_assets_in_view


### PR DESCRIPTION
The code was taken off @tdwalton's issue #90.  Adding a unit test for the error.  I left the version number the same. 
